### PR TITLE
Fix build command for multi-root workspaces

### DIFF
--- a/src/commands/buildManager.ts
+++ b/src/commands/buildManager.ts
@@ -21,20 +21,21 @@ export class BuildManager {
   }
 
   public async buildSelectedFile(): Promise<void> {
-    if (!isDartProject()) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage(
+        localize('extension.noActiveFileMessage', 'No active file to build.')
+      );
+      return;
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+    if (!workspaceFolder || !isDartProject(workspaceFolder.uri)) {
       vscode.window.showErrorMessage(
         localize(
           'extension.noDartProjectMessage',
           'No Dart project detected in the current directory.'
         )
-      );
-      return;
-    }
-
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showErrorMessage(
-        localize('extension.noActiveFileMessage', 'No active file to build.')
       );
       return;
     }
@@ -53,7 +54,7 @@ export class BuildManager {
       }
     }
 
-    const workspaceRoot = vscode.workspace.rootPath || '';
+    const workspaceRoot = workspaceFolder.uri.fsPath;
     const relativePath = path.relative(workspaceRoot, editor.document.uri.fsPath);
 
     const command = process.platform === 'win32' ? 'cmd' : 'dart';

--- a/src/commands/watchManager.ts
+++ b/src/commands/watchManager.ts
@@ -40,7 +40,8 @@ export class WatchManager {
     if (this.watchProcess) {
       await this.stopWatch();
     } else {
-      if (!isDartProject()) {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      if (!workspaceFolder || !isDartProject(workspaceFolder.uri)) {
         vscode.window.showErrorMessage(
           localize(
             'extension.noDartProjectMessage',
@@ -69,6 +70,7 @@ export class WatchManager {
   }
 
   private async startWatch() {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     const command = process.platform === 'win32' ? 'cmd' : 'dart';
     const args =
       process.platform === 'win32'
@@ -78,7 +80,7 @@ export class WatchManager {
     this.outputChannel.clear();
     this.outputChannel.show(true);
 
-    this.watchProcess = spawn(command, args, { cwd: vscode.workspace.rootPath });
+    this.watchProcess = spawn(command, args, { cwd: workspaceFolder?.uri.fsPath });
 
     this.watchProcess.stdout.on('data', (data) => {
       this.outputChannel.append(`[build_runner]: ${data}`);

--- a/src/utils/projectUtils.ts
+++ b/src/utils/projectUtils.ts
@@ -6,8 +6,12 @@ import * as nls from 'vscode-nls';
 
 const localize = nls.config({ messageFormat: nls.MessageFormat.file })();
 
-export function isDartProject(): boolean {
-  const pubspecPath = path.join(vscode.workspace.rootPath || '', 'pubspec.yaml');
+export function isDartProject(uri?: vscode.Uri): boolean {
+  const folder = uri
+    ? vscode.workspace.getWorkspaceFolder(uri)
+    : vscode.workspace.workspaceFolders?.[0];
+  const rootPath = folder?.uri.fsPath || '';
+  const pubspecPath = path.join(rootPath, 'pubspec.yaml');
   return fs.existsSync(pubspecPath);
 }
 


### PR DESCRIPTION
## Summary
- detect the workspace folder when building a single file
- use workspace folder path instead of deprecated `rootPath`
- update dart project detection to accept a URI

## Testing
- `npm install --silent`
- `npm run compile --silent`
- `npx tsc -p ./`

------
https://chatgpt.com/codex/tasks/task_e_6843bcb436f88328a9595aa15751be0b